### PR TITLE
fix: remove overly broad SonarQube exclusion pattern

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -4,7 +4,7 @@ sonar.projectVersion=0.1.0
 
 # Source code location
 sonar.sources=ui
-sonar.exclusions=**/*
+sonar.exclusions=**/node_modules/**,**/build/**,**/dist/**,**/test-results/**,**/playwright-report/**,.next/**
 
 # Encoding of the source code
 sonar.sourceEncoding=UTF-8


### PR DESCRIPTION
## Summary  
- Remove `sonar.exclusions=**/*` that excludes ALL files from analysis
- Replace with specific exclusions for build artifacts and dependencies
- Allows SonarQube to analyze actual source code

## Problem
The current configuration `sonar.exclusions=**/*` excludes every file, causing SonarQube to find 0 files to analyze and fail with "Project not found" error.

## Solution
Changed to exclude only unnecessary files:
- node_modules, build, dist directories
- Test results and Playwright reports  
- Next.js build cache

This is the minimal change needed to unblock SonarQube scanning.

## Test plan
- SonarQube scan should now find and analyze source files
- Quality gates should run properly